### PR TITLE
Add license key to client area

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# jetpack-whmcs-provisioning-module
-A provisioning module for WHMCS for Jetpack distribution
+# Jetpack WHMCS Provisioning Module
+The Jetpack [WHMCS provisioning module](https://developers.whmcs.com/provisioning-modules/) is intended to assist Jetpack hosting partners who utilize WHMCS in managing Jetpack products for their users. The modules option is available when a product or product addon is created that implements the Jetpack WHMCS provisioning module in the list of available modules.
+
+Once a purchase for a Jetpack product has been completed through WHMCS the Jetpack license can be issued based on one of the 4 available options in WHMCS when creating a new product that involves a module for provisioning(3 Automatic provisioning options and the option to not provision under Module Settings when creating a product).
+
+The provisioning module uses standard WHMCS [functions](https://developers.whmcs.com/provisioning-modules/supported-functions/) for creating and terminating accounts to issue and revoke Jetpack licenses using the Jetpack Licensing API. Module functions include both automattic license issuing on checkout as well as the option to both issue and revoke a license using the create and terminate options available with the module.
+
+## Getting Started
+If you’d like to become a Jetpack Hosting Partner please take a look at the [Jetpack Hosting Partner Information Page](https://jetpack.com/for/hosts/) for more information and to get started. In order to use the module a valid WHMCS license as well as a Jetpack Hosting Partner account and API token are required. To get started with WHMCS please visit https://www.whmcs.com/.
+
+## Setup
+To install this module clone this repository in a folder named `jetpack` in the `modules/servers` directory. A server is not required for the module to function so the module will not be listed in the WHMCS Servers under the Setup tab for Products/Servers. Once the jetpack folder has been created with the module files the module is ready for use with new or existing products.
+
+## Usage
+To use the provisioing module create a new product or product addon in one of your existing product groups. As part of the product creation process in the Module Settings tab, select the “Jetpack Provisioning" module to get started. You will need to have an established Jetpack Hosting Partner account and your partner API token will be requested in order to utilize the Jetpack licensing API. The provisioning module will create a table `jetpack_product_licenses` on it's first use if the table has not previously been created either by the [addon module](https://github.com/Automattic/jetpack-whmcs-addon-module) or previous use of the provisioning module.
+
+## Configuration Options
+The provisioning module has 2 configuration options
+- API Token: Your API token mentioned above which is required for using the Jetpack licensing API.
+- Jetpack Product: The Jetpack product that will be tied to the product being created/sold in WHMCS

--- a/README.md
+++ b/README.md
@@ -1,20 +1,2 @@
-# Jetpack WHMCS Provisioning Module
-The Jetpack [WHMCS provisioning module](https://developers.whmcs.com/provisioning-modules/) is intended to assist Jetpack hosting partners who utilize WHMCS in managing Jetpack products for their users. The modules option is available when a product or product addon is created that implements the Jetpack WHMCS provisioning module in the list of available modules.
-
-Once a purchase for a Jetpack product has been completed through WHMCS the Jetpack license can be issued based on one of the 4 available options in WHMCS when creating a new product that involves a module for provisioning(3 Automatic provisioning options and the option to not provision under Module Settings when creating a product).
-
-The provisioning module uses standard WHMCS [functions](https://developers.whmcs.com/provisioning-modules/supported-functions/) for creating and terminating accounts to issue and revoke Jetpack licenses using the Jetpack Licensing API. Module functions include both automattic license issuing on checkout as well as the option to both issue and revoke a license using the create and terminate options available with the module.
-
-## Getting Started
-If you’d like to become a Jetpack Hosting Partner please take a look at the [Jetpack Hosting Partner Information Page](https://jetpack.com/for/hosts/) for more information and to get started. In order to use the module a valid WHMCS license as well as a Jetpack Hosting Partner account and API token are required. To get started with WHMCS please visit https://www.whmcs.com/.
-
-## Setup
-To install this module clone this repository in a folder named `jetpack` in the `modules/servers` directory. A server is not required for the module to function so the module will not be listed in the WHMCS Servers under the Setup tab for Products/Servers. Once the jetpack folder has been created with the module files the module is ready for use with new or existing products.
-
-## Usage
-To use the provisioing module create a new product or product addon in one of your existing product groups. As part of the product creation process in the Module Settings tab, select the “Jetpack Provisioning" module to get started. You will need to have an established Jetpack Hosting Partner account and your partner API token will be requested in order to utilize the Jetpack licensing API. The provisioning module will create a table `jetpack_product_licenses` on it's first use if the table has not previously been created either by the [addon module](https://github.com/Automattic/jetpack-whmcs-addon-module) or previous use of the provisioning module.
-
-## Configuration Options
-The provisioning module has 2 configuration options
-- API Token: Your API token mentioned above which is required for using the Jetpack licensing API.
-- Jetpack Product: The Jetpack product that will be tied to the product being created/sold in WHMCS
+# jetpack-whmcs-provisioning-module
+A provisioning module for WHMCS for Jetpack distribution

--- a/jetpack.php
+++ b/jetpack.php
@@ -213,7 +213,7 @@ function jetpack_AdminServicesTabFields($params)
     $license_key = (new JetpackLicenseManager() )->getLicenseKey($params['model']['orderid'], $params['pid']);
     $license_key = isset($license_key) ? $license_key : 'No License Key Found';
     return [
-     'License Key' => '<input type="text" name="licensekey" disabled size="60" value="' . $license_key . '" />',
+     'License Key' => '<input type="text" name="licensekey" class="form-control input-300" disabled size="60" value="' . $license_key . '" />',
     ];
 }
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -218,6 +218,32 @@ function jetpack_AdminServicesTabFields($params)
 }
 
 /**
+ * Output Jetpack License to the WHMCS client area.
+ *
+ * @param array WHMCS $params
+ * @return array Client Area output.
+ */
+function jetpack_ClientArea($params)
+{
+    $license_key = (new JetpackLicenseManager() )->getLicenseKey($params['model']['orderid'], $params['pid']);
+    $license_key = isset($license_key) ? $license_key : 'No License Key Found';
+
+    $domain = null;
+    if (isset($params['domain'])) {
+        $domain = trim($params['domain'], '/');
+        $domain = parse_url($domain, PHP_URL_PATH);
+    }
+
+    return [
+        'templatefile' => 'jetpack_license',
+        'vars' => [
+            'license_key' => $license_key,
+            'domain' => $domain,
+        ],
+    ];
+}
+
+/**
  * Parse Jetpack License APi response errors on non 200 responses
  *
  * @param Exception $e

--- a/templates/jetpack_license.tpl
+++ b/templates/jetpack_license.tpl
@@ -14,7 +14,7 @@
 
 <p>
     {if $domain}
-        Ready to activate your license? Copy your license above and click <a href="http://{$domain}/wp-admin/admin.php?page=jetpack#/license/activation" target="_blank"> here </a> to do so.
+        Need to activate your license? Copy your license above and click <a href="http://{$domain}/wp-admin/admin.php?page=jetpack#/license/activation" target="_blank"> here </a> to do so.
     {/if}
 </p>
 

--- a/templates/jetpack_license.tpl
+++ b/templates/jetpack_license.tpl
@@ -1,0 +1,23 @@
+<p>
+    <div class="row">
+        <div class="col-sm-5 text-right"> <strong> Your Jetpack License Key </strong> </div>
+
+        <div class="col-sm-7 text-left">{$license_key}
+            <input type="text" id="licenseKey" hidden value="{$license_key}" >
+            <button type="button" class="btn btn-default btn-xs copy-to-clipboard" data-clipboard-target="#licenseKey">
+                <img src="{$WEB_ROOT}/assets/img/clippy.svg" alt="Copy to clipboard" width="15">
+                {lang key='copy'}
+            </button>
+        </div>
+    </div>
+</p>
+
+<p>
+    {if $domain}
+        Ready to activate your license? Copy your license above and click <a href="http://{$domain}/wp-admin/admin.php?page=jetpack#/license/activation" target="_blank"> here </a> to do so.
+    {/if}
+</p>
+
+<p>
+    Need help getting started with Jetpack? Follow the instructions we've put together <a href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/" target="_blank"> here. </a>.
+</p>


### PR DESCRIPTION
Add jetpack license key output to the client area. Also add a link to activate the license if a domain is present and a link to support documentation for getting started.